### PR TITLE
Update media query hamburger.css

### DIFF
--- a/src/components/hamburger/hamburger.css
+++ b/src/components/hamburger/hamburger.css
@@ -59,7 +59,7 @@
     transform: rotate(90deg);
 }
 
-@media (max-width: 700px) {
+@media (max-width: 800px) {
     .menu-toggle {
         display: block;
     }


### PR DESCRIPTION
Insted of setting the max-width of the hamburger menu to 700px, I set it to 800px because as soon as the navbar is gone there's a blank space in the header. This only happens between 701px and 800px.